### PR TITLE
Setup Github Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,26 @@
+name: "@ebay/browserslist-config"
+on: [push]
+jobs:
+  unit-tests:
+    name: Linting
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: yarn
+      - name: Execute tests
+        run: yarn lint
+
+  linting:
+    name: Unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: yarn
+      - name: Execute tests
+        run: yarn test


### PR DESCRIPTION
Use Github Actions for running the tests and linting upon push.

The executed scripts are introduced in #5 