### PR TITLE
Remove Android native browser 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,5 @@ module.exports = [
     'Edge >= 87',
     'Opera >= 73',
     'ChromeAndroid >= 75',
-    'ios_saf >= 9',
-    'Android >= 4'
+    'ios_saf >= 9'
 ];


### PR DESCRIPTION
This will resolve issue #16 
~~Please wait for the approval (see issue #16) first before we merge this PR.~~ We got the [approval to remove Android 4](https://github.com/eBay/browserslist-config/issues/16#issuecomment-864223724). Should create a release patch for this.