### PR TITLE
Update Edge and Opera min version

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ module.exports = [
     'Firefox >= 78',
     'Safari >= 10',
     'Edge 18',
-    'Edge >= 94',
-    'Opera >= 78',
+    'Edge >= 95',
+    'Opera >= 80',
     'ChromeAndroid >= 75',
     'ios_saf >= 9'
 ];


### PR DESCRIPTION
Update the supported browsers set based on traffic on Feb 2022:

- Edge: 94 → 95+
- Opera: 78 → 80+