### PR TITLE
Update browserlist based on July 2022 Policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Reflect changes of Browser Policy July 2022 (Edge, Opera, and Safari mobile)
+
+## [2.2.0]
+
+### Changed
+
+- Reflect changes of Browser Policy Feb 2022 (Edge & Opera)
+
+## [2.1.0]
+
+### Changed
+
+- Reflect changes of Browser Policy Dec 2021 (Chrome, Edge, & Opera)
+
 ## [2.0.2]
 
 ### Fixed

--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ module.exports = [
     'Firefox >= 78',
     'Safari >= 10',
     'Edge 18',
-    'Edge >= 95',
-    'Opera >= 80',
+    'Edge >= 97',
+    'Opera >= 82',
     'ChromeAndroid >= 75',
-    'ios_saf >= 9'
+    'ios_saf >= 10'
 ];


### PR DESCRIPTION
Update browser versions to support at least Tier 2, based on BrowserPolicy July 2021 update:

### Desktop

- Tier 1: Edge → 97+
- Tier 2: Opera → 82+

### Mobile

- Tier 2: Safari mobile from 9 → 10-11