### PR TITLE
Update with Sept 2024 revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [2.10.0]
+
+### Changed
+
+- Reflect changes of Browser Policy Sept 2024
+
 ## [2.9.0]
 
 ### Changed

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 module.exports = [
     'Chrome >= 103',
     'Firefox >= 78',
-    'Safari >= 12',
+    'Safari >= 13',
     'Edge >= 109',
     'Opera >= 95',
-    'ChromeAndroid >= 106',
+    'ChromeAndroid >= 111',
     'ios_saf >= 14'
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebay/browserslist-config",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebay/browserslist-config",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "license": "MIT",
       "devDependencies": {
         "browserslist": "^4.16.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebay/browserslist-config",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "The Browserslist config for eBay.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# Sept 2024 (Q3) updates

## Policy changes
- Updated Safari dWeb Tier 2 from 12+ to 13+
- Updated Chrome mWeb Tier 1 from 115+ to 119+
- Updated Chrome Mobile Tier 2 from 106+ to 111+

## Updates to config
- Updated `Safari >= 12` to `Safari >= 13`
- Updated `ChromeAndroid >= 106` to `ChromeAndroid >= 111`