### PR TITLE
Update with Q3 2025 revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.12.0]
+
+### Changed
+
+- Reflect changes of Browser Policy Q3 2025
+
 ## [2.11.0]
 
 ### Changed

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 module.exports = [
-    'Chrome >= 103',
-    'Firefox >= 78',
+    'Chrome >= 109',
+    'Firefox >= 115',
     'Safari >= 14',
     'Edge >= 109',
     'Opera >= 95',
-    'ChromeAndroid >= 111',
-    'ios_saf >= 14'
+    'ChromeAndroid >= 130',
+    'ios_saf >= 15'
 ];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebay/browserslist-config",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "The Browserslist config for eBay.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# September 2025 (Q3) updates

- Updated the config based on the Tier 2 ones
- Major bump 14 to 15 for iOS Safari
- Bump version to v2.12.0