### PR TITLE
Update with Q4 2025 revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.13.0]
+
+### Changed
+
+- Reflect changes of Browser Policy Q4 2025
+
 ## [2.12.0]
 
 ### Changed

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 module.exports = [
     'Chrome >= 109',
     'Firefox >= 115',
-    'Safari >= 14',
-    'Edge >= 109',
+    'Safari >= 15.4',
+    'Edge >= 140',
     'Opera >= 95',
     'ChromeAndroid >= 130',
-    'ios_saf >= 15'
+    'ios_saf >= 15.4'
 ];


### PR DESCRIPTION
# December 2025 (Q4) updates

- Updated the config based on the Tier 2 ones
- Major bump 14 to 15.5 for MacOS Safari
- Bump version to v2.13.0